### PR TITLE
Fix iOS scroll snap & click events

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,7 @@
       </header>
       <div class="spacer"></div>
     </section>
-    <section class="scrolling">
+    <section class="scrolling" onclick="void(0)">
       <section class="title">
         <div class="spacer"></div>
         <div class="svg-wrapper">

--- a/src/scripts/theme-switcher.js
+++ b/src/scripts/theme-switcher.js
@@ -22,9 +22,6 @@ function switchTheme() {
 }
 
 export default () => {
-  root.addEventListener("click", e => {
-    switchTheme();
-  });
-
+  root.onclick = switchTheme;
   switchTheme(); // Set initial theme on page load
 };

--- a/src/styles/animations.scss
+++ b/src/styles/animations.scss
@@ -8,6 +8,7 @@ nav .scroll-arrow-wrapper .scroll-arrow {
 
 .scrolling {
   scroll-snap-type: y mandatory;
+  -webkit-overflow-scrolling: touch;
 
   .title {
     scroll-snap-align: start;


### PR DESCRIPTION
This is an attempt to fix `scroll-snap` behaviour, and an issue with browsers on iOS [not firing click events](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event#Safari_Mobile). It mostly works with this change but there's a bit of a quirk where the first tap after scrolling to a `scroll-snap` element still doesn't fire the event. Subsequent taps work correctly though.

I read a few vague things about `position: fixed` (which is used on the hero image element) causing weird problems on iOS, that may be a factor.